### PR TITLE
`gpkg_add_contents()`: more intelligent choice of data type

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gpkg
 Type: Package
 Title: Utilities for the OGC 'GeoPackage' Format
-Version: 0.0.5
+Version: 0.0.5.9001
 Authors@R: person(given="Andrew", family="Brown", email="brown.andrewg@gmail.com", role = c("aut", "cre"))
 Maintainer: Andrew Brown <brown.andrewg@gmail.com>
 Description: High-level wrapper functions to build Open Geospatial Consortium (OGC) 'GeoPackage' files (<https://www.geopackage.org/>). 'GDAL' utilities for read and write of spatial data are provided via the 'terra' package. Additional 'GeoPackage' and 'SQLite' specific functions manipulate attributes and tabular data via the 'RSQLite' package.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# gpkg 0.0.5.9001
+
+ - Improvement to `gpkg_add_contents()` and `gpkg_update_contents()`: more intelligent choice of data type when heterogeneous (non-attribute) data are in database but not registered. Fix for broken tests on Windows/GDAL 3.5.2.
+
 # gpkg 0.0.5
 
  - Fixed bug in `gpkg_tables()` when multiple attribute tables were present.

--- a/man/gpkg-contents.Rd
+++ b/man/gpkg-contents.Rd
@@ -7,13 +7,19 @@
 \alias{gpkg_create_contents}
 \title{Add, Remove, Update and Create \code{gpkg_contents} table and records}
 \usage{
-gpkg_add_contents(x, table_name, description = "", template = NULL)
+gpkg_add_contents(
+  x,
+  table_name,
+  description = "",
+  template = NULL,
+  query_string = FALSE
+)
 
 gpkg_update_contents(x)
 
-gpkg_delete_contents(x, table_name)
+gpkg_delete_contents(x, table_name, query_string = FALSE)
 
-gpkg_create_contents(x)
+gpkg_create_contents(x, query_string = FALSE)
 }
 \arguments{
 \item{x}{A \emph{geopackage}}
@@ -23,6 +29,8 @@ gpkg_create_contents(x)
 \item{description}{Default \code{""}}
 
 \item{template}{Default \code{NULL} uses global EPSG:4326 with bounds -180,-90:180,90}
+
+\item{query_string}{\emph{logical}. Return SQLite statement rather than executing it? Default: \code{FALSE}}
 }
 \value{
 logical. TRUE on successful execution of SQL statements.


### PR DESCRIPTION
 - when heterogeneous (non-attribute) data are in database but not registered
 - fix for broken tests on Windows/GDAL 3.5.2
   - where (apparently) `gpkg_contents` does not get updated the same way as 3.6.x so consistent behavior across relies on `gpkg_update_contents()` to detect table data type