### PR TITLE
Implement GDAL driver detection via {vapour} 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gpkg
 Type: Package
 Title: Utilities for the Open Geospatial Consortium 'GeoPackage' Format
-Version: 0.0.8
+Version: 0.0.9
 Authors@R: person(given="Andrew", family="Brown", email="brown.andrewg@gmail.com", role = c("aut", "cre"))
 Maintainer: Andrew Brown <brown.andrewg@gmail.com>
 Description: Build Open Geospatial Consortium 'GeoPackage' files (<https://www.geopackage.org/>). 'GDAL' utilities for reading and writing spatial data are provided by the 'terra' package. Additional 'GeoPackage' and 'SQLite' features for attributes and tabular data are implemented with the 'RSQLite' package.
@@ -14,6 +14,7 @@ Imports:
 Suggests: 
     RSQLite,
     terra (>= 1.6),
+    vapour,
     tinytest,
     dplyr,
     dbplyr,
@@ -21,7 +22,7 @@ Suggests:
     rmarkdown
 License: CC0
 Depends: R (>= 3.1.0)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Roxygen: list(markdown = TRUE)
 Encoding: UTF-8
 LazyData: true

--- a/R/gpkg-io.R
+++ b/R/gpkg-io.R
@@ -1,12 +1,13 @@
 #' Read data from a GeoPackage
 #'
-#' Experimental: This function is being evaluated for its scope compared to other more general functions that perform similar operations (i.e. `gpkg_tables()`).
+#' This function creates a _geopackage_ object with references to all tables from the GeoPackage source specified in `x`. For a simple list of tables see `gpkg_tables()`.
 #'
 #' @param x Path to GeoPackage
 #' @param connect Connect to database and store connection in result? Default: `FALSE`
 #' @param quiet Hide printing of gdalinfo description to stdout. Default: `TRUE`
 #' @return A _geopackage_ object (list containing tables, grids and vector data)
 #' @export
+#' @seealso [gpkg_tables()]
 #' @keywords io
 gpkg_read <- function(x, connect = FALSE, quiet = TRUE) {
   if (inherits(x, 'geopackage')) {
@@ -72,6 +73,9 @@ gpkg_read <- function(x, connect = FALSE, quiet = TRUE) {
 #' @param gdal_options Additional `gdal_options`, passed to `terra::writeRaster()`
 #' @param ... Additional arguments are passed as GeoPackage "creation options." See Details.
 #' @details Additional, non-default GeoPackage creation options can be specified as arguments to this function. The full list of creation options can be viewed [here](https://gdal.org/drivers/raster/gpkg.html#creation-options) or in the `gpkg_creation_options` dataset. The name of the argument is `creation_option` and the value is selected from one of the elements of `values` for that option.
+#' 
+#' If `x` contains source file paths, any comma-separated value (CSV) files are treated as attribute data--even if they contain a geometry column. GeoPackage source file paths are always treated as vector data sources, and only one layer will be read from the source and written to the target. If you need to read raster data from a GeoPackage first create a `SpatRaster`  from the layer of interest (see `gpkg_rast()`) before passing to `gpkg_write()`. If you need to read multiple layers from any multi-layer source read them individually into suitable objects. For a source GeoPackage containing multiple layers you can use `gpkg_read()` (returns a _geopackage_ object) or `gpkg_tables()` (returns a _list_ object).
+#' 
 #' @return Logical. `TRUE` on successful write of at least one grid.
 #' @seealso [gpkg_creation_options]
 #' @export

--- a/R/gpkg-table.R
+++ b/R/gpkg-table.R
@@ -60,7 +60,7 @@ gpkg_table_pragma.geopackage <- function(x, table_name = NULL, ...) {
 #' @export
 #' @rdname gpkg_table
 #' @examplesIf !inherits(try(requireNamespace("RSQLite", quietly = TRUE)), 'try-error') &&!inherits(try(requireNamespace("dbplyr", quietly = TRUE)), 'try-error') && !inherits(try(requireNamespace("terra", quietly = TRUE)), 'try-error')
-#' @description `gpkg_table()`: access a specific table (by name) and get a "lazy" `tibble` object referencing that table
+#' @description `gpkg_table()`: Access a specific table (by name) and get a "lazy" {dbplyr} _tbl_SQLiteConnection_ object referencing that table
 #' @return `gpkg_table()`: A 'dbplyr' object of class _tbl_SQLiteConnection_
 #' @examples 
 #' 
@@ -135,7 +135,7 @@ gpkg_table.default <- function(x,
   dplyr::tbl(con, table_name, ...)
 }
 
-#' @description `gpkg_collect()`: alias for `gpkg_table(..., collect=TRUE)`
+#' @description `gpkg_collect()`: Alias for `gpkg_table(..., collect=TRUE)`
 #' @return `gpkg_collect()`: An object of class _data.frame_
 #' @rdname gpkg_table
 #' @export
@@ -143,7 +143,7 @@ gpkg_collect <- function(x, table_name, query_string = FALSE, ...) {
   gpkg_table(x, table_name, ..., query_string = query_string, collect = TRUE)
 }
 
-#' @description `gpkg_tbl()`: shorthand for `gpkg_table(..., collect=FALSE)`(default) that always returns a 'dplyr' object.
+#' @description `gpkg_tbl()`: Alias for `gpkg_table(..., collect=FALSE)`(default) that _always_ returns a _tbl_SQLiteConnection_ object.
 #' @return `gpkg_tbl()`: An object of class _tbl_SQLiteConnection_
 #' @rdname gpkg_table
 #' @export
@@ -151,6 +151,7 @@ gpkg_tbl <- function(x, table_name, ...) {
   gpkg_table(x, table_name, ..., collect = FALSE)
 }
 
+#' @description `gpkg_rast()`: Get a _SpatRaster_ object corresponding to the specified `table_name`
 #' @return `gpkg_rast()`: A 'terra' object of class _SpatRaster_
 #' @export
 #' @rdname gpkg_table
@@ -167,6 +168,7 @@ gpkg_rast <- function(x, table_name = NULL, ...) {
 }
 
 
+#' @description `gpkg_rast()`: Get a _SpatVector_ object corresponding to the specified `table_name`
 #' @return `gpkg_vect()`: A 'terra' object of class _SpatVector_ (may not contain geometry columns)
 #' @export
 #' @rdname gpkg_table

--- a/man/gpkg_read.Rd
+++ b/man/gpkg_read.Rd
@@ -17,6 +17,9 @@ gpkg_read(x, connect = FALSE, quiet = TRUE)
 A \emph{geopackage} object (list containing tables, grids and vector data)
 }
 \description{
-Experimental: This function is being evaluated for its scope compared to other more general functions that perform similar operations (i.e. \code{gpkg_tables()}).
+This function creates a \emph{geopackage} object with references to all tables from the GeoPackage source specified in \code{x}. For a simple list of tables see \code{gpkg_tables()}.
+}
+\seealso{
+\code{\link[=gpkg_tables]{gpkg_tables()}}
 }
 \keyword{io}

--- a/man/gpkg_table.Rd
+++ b/man/gpkg_table.Rd
@@ -58,11 +58,15 @@ gpkg_vect(x, table_name, ...)
 \description{
 \code{gpkg_table_pragma()}: Get information on a table in a GeoPackage (without returning the whole table).
 
-\code{gpkg_table()}: access a specific table (by name) and get a "lazy" \code{tibble} object referencing that table
+\code{gpkg_table()}: Access a specific table (by name) and get a "lazy" {dbplyr} \emph{tbl_SQLiteConnection} object referencing that table
 
-\code{gpkg_collect()}: alias for \code{gpkg_table(..., collect=TRUE)}
+\code{gpkg_collect()}: Alias for \code{gpkg_table(..., collect=TRUE)}
 
-\code{gpkg_tbl()}: shorthand for \code{gpkg_table(..., collect=FALSE)}(default) that always returns a 'dplyr' object.
+\code{gpkg_tbl()}: Alias for \code{gpkg_table(..., collect=FALSE)}(default) that \emph{always} returns a \emph{tbl_SQLiteConnection} object.
+
+\code{gpkg_rast()}: Get a \emph{SpatRaster} object corresponding to the specified \code{table_name}
+
+\code{gpkg_rast()}: Get a \emph{SpatVector} object corresponding to the specified \code{table_name}
 }
 \examples{
 \dontshow{if (!inherits(try(requireNamespace("RSQLite", quietly = TRUE)), 'try-error') &&!inherits(try(requireNamespace("dbplyr", quietly = TRUE)), 'try-error') && !inherits(try(requireNamespace("terra", quietly = TRUE)), 'try-error')) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/man/gpkg_write.Rd
+++ b/man/gpkg_write.Rd
@@ -43,6 +43,8 @@ Write data to a GeoPackage
 }
 \details{
 Additional, non-default GeoPackage creation options can be specified as arguments to this function. The full list of creation options can be viewed \href{https://gdal.org/drivers/raster/gpkg.html#creation-options}{here} or in the \code{gpkg_creation_options} dataset. The name of the argument is \code{creation_option} and the value is selected from one of the elements of \code{values} for that option.
+
+If \code{x} contains source file paths, any comma-separated value (CSV) files are treated as attribute data--even if they contain a geometry column. GeoPackage source file paths are always treated as vector data sources, and only one layer will be read from the source and written to the target. If you need to read raster data from a GeoPackage first create a \code{SpatRaster}  from the layer of interest (see \code{gpkg_rast()}) before passing to \code{gpkg_write()}. If you need to read multiple layers from any multi-layer source read them individually into suitable objects. For a source GeoPackage containing multiple layers you can use \code{gpkg_read()} (returns a \emph{geopackage} object) or \code{gpkg_tables()} (returns a \emph{list} object).
 }
 \seealso{
 \link{gpkg_creation_options}


### PR DESCRIPTION
This implements better handling of file paths to detect the necessary GDAL drivers. It is able to distinguish between raster and vector in most cases. 

To be consistent with prior behavior, for now, the GDAL CSV driver is ignored as a possible vector source (used for non-spatial attributes only) and the GPKG driver is only used as a vector source. 
 - It appears that {terra} can not properly read and write vector data from CSV anyway. 
 - It is questionable whether GPKG (or any other multilayer sources) should be allowed in the current scheme. If there is more than one spatial layer in the source the current 1:1 mapping of source to new table becomes ambiguous without the ability to either select a specific layer, or transfer all layers.

There are several other drivers (which previously did not work as their extensions were not in the hard coded list) which can serve as both vector and raster sources. 

```r
drv <- vapour::vapour_all_drivers()
drv$driver[drv$vector & drv$raster]
#> [1] "FITS"        "PCIDSK"      "netCDF"      "PDS4"        "VICAR"       "JP2OpenJPEG"
#> [7] "PDF"         "MBTiles"     "BAG"         "OGCAPI"      "GPKG"        "OpenFileGDB"
#> [13] "CAD"         "PLSCENES"    "NGW"         "HTTP"       
```

There may need to be some specific handling of the above, and then the set of decisions documented in the documentation Details. The option is always available to read from the source using the correct format before passing to `gpkg_write()`, this would only affect file path source driver detection.