### PR TITLE
gpkg_write: deprecate `destfile` and replace with `y`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gpkg
 Type: Package
 Title: Utilities for the Open Geospatial Consortium 'GeoPackage' Format
-Version: 0.0.12
+Version: 0.0.13
 Authors@R: person(given="Andrew", family="Brown", email="brown.andrewg@gmail.com", role = c("aut", "cre"))
 Maintainer: Andrew Brown <brown.andrewg@gmail.com>
 Description: Build Open Geospatial Consortium 'GeoPackage' files (<https://www.geopackage.org/>). 'GDAL' utilities for reading and writing spatial data are provided by the 'terra' package. Additional 'GeoPackage' and 'SQLite' features for attributes and tabular data are implemented with the 'RSQLite' package.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# gpkg 0.0.13
+
+ - Deprecated `destfile` argument to `gpkg_write()` and replaced with `y`, which now accepts _geopackage_ or _DBIConnection_ objects
+ 
 # gpkg 0.0.12
  
  - Major cleanup and more consistent use of internal _SQLiteConnection_ usage to ensure open connections don't get garbage collected

--- a/R/gpkg-class.R
+++ b/R/gpkg-class.R
@@ -30,7 +30,7 @@ geopackage.list <- function(x, dsn = NULL, connect = FALSE, ...) {
     dsn <- tempfile("Rgpkg", fileext = ".gpkg")
   }
   if (is.character(dsn) && !file.exists(dsn)) {
-    res <- gpkg_write(x, destfile = dsn, ...)
+    res <- gpkg_write(x, dsn, ...)
   } else {
     if (!all(names(x) %in% gpkg_list_tables(dsn))) {
       stop("File (", dsn, ") already exists! `geopackage(<list>)` should only be used when the GeoPackage `dsn` needs to be created. See the `geopackage(<character>)` and `geopackage(<SQLiteConnection>)` methods (without list input) to use existing databases.", call. = FALSE)

--- a/R/gpkg-io.R
+++ b/R/gpkg-io.R
@@ -79,19 +79,20 @@ gpkg_read <- function(x, connect = FALSE, quiet = TRUE) {
 
 #' Write data to a GeoPackage
 #' @param x Vector of source file path(s), or a list containing one or more
-#'   SpatRaster, SpatRasterCollection, or SpatVectorProxy objects.
-#' @param destfile Character. Path to output GeoPackage
-#' @param table_name Character. Default `NULL` name is derived from source file.
+#'   SpatRaster, SpatRasterCollection, SpatVectorProxy, or data.frame objects.
+#' @param y _character_, _geopackage_, or _DBIConnection_. 
+#' @param destfile _character_. Path to output GeoPackage
+#' @param table_name _character_. Default `NULL` name is derived from source file.
 #'   Required if `x` is a _data.frame_.
-#' @param datatype Data type. Defaults to `"FLT4S"` for GeoTIFF files, `"INT2U"`
+#' @param datatype _character_. Data type. Defaults to `"FLT4S"` for GeoTIFF files, `"INT2U"`
 #'   otherwise. See documentation for `terra::writeRaster()`.
-#' @param append Append to existing data source? Default: `FALSE`. Setting
+#' @param append _logical_. Append to existing data source? Default: `FALSE`. Setting
 #'   `append=TRUE` overrides `overwrite=TRUE`
-#' @param overwrite Overwrite existing data source? Default `FALSE`.
-#' @param NoData Value to use as GDAL `NoData` Value
-#' @param gdal_options Additional `gdal_options`, passed to
+#' @param overwrite _logical_. Overwrite existing data source? Default `FALSE`.
+#' @param NoData _numeric_. Value to use as GDAL `NoData` Value
+#' @param gdal_options _character_. Additional `gdal_options`, passed to
 #'   `terra::writeRaster()`
-#' @param ... Additional arguments are passed as GeoPackage "creation options."
+#' @param ... Additional arguments are passed as GeoPackage creation options.
 #'   See Details.
 #' @details Additional, non-default GeoPackage creation options can be specified
 #'   as arguments to this function. The full list of creation options can be
@@ -117,16 +118,30 @@ gpkg_read <- function(x, connect = FALSE, quiet = TRUE) {
 #' @export
 #' @keywords io
 gpkg_write <- function(x,
-                       destfile,
+                       y = NULL,
                        table_name = NULL,
                        datatype = "FLT4S",
                        append = FALSE,
                        overwrite = FALSE,
                        NoData = NULL,
                        gdal_options = NULL,
+                       destfile = NULL,
                        ...) {
-  res <- .gpkg_process_sources(x, 
-                               destfile,
+  
+  if (!missing(destfile)) {
+    .Deprecated(msg = "Argument `destfile` is deprecated; use `y`")
+    y <- destfile
+  }
+  
+  if (inherits(y, 'geopackage')) {
+    y <- gpkg_connection(y)
+  }
+  
+  if (inherits(y, 'DBIConnection')) {
+    y <- DBI::dbGetInfo(y)$dbname
+  }
+  
+  res <- .gpkg_process_sources(x, y,
                                table_name = table_name,
                                datatype = datatype,
                                append = append,

--- a/R/gpkg-table.R
+++ b/R/gpkg-table.R
@@ -55,13 +55,11 @@ gpkg_table_pragma.default <- function(x, table_name = NULL, ...) {
 #' 
 #' r <- terra::rast(system.file("extdata", "dem.tif", package = "gpkg"))
 #'
-#' gpkg_write(r,
-#'            destfile = tf,
+#' gpkg_write(r, tf,
 #'            RASTER_TABLE = "DEM1",
 #'            FIELD_NAME = "Elevation")
 #' 
-#' gpkg_write(r,
-#'            destfile = tf,
+#' gpkg_write(r, tf,
 #'            append = TRUE,
 #'            RASTER_TABLE = "DEM2",
 #'            FIELD_NAME = "Elevation")

--- a/README.Rmd
+++ b/README.Rmd
@@ -74,15 +74,13 @@ if (file.exists(gpkg_tmp))
 
 # write a gpkg with two DEMs in it
 gpkg_write(
-  dem,
-  destfile = gpkg_tmp,
+  dem, gpkg_tmp,
   RASTER_TABLE = "DEM1",
   FIELD_NAME = "Elevation"
 )
 
 gpkg_write(
-  dem,
-  destfile = gpkg_tmp,
+  dem, gpkg_tmp,
   append = TRUE,
   RASTER_TABLE = "DEM2",
   FIELD_NAME = "Elevation",
@@ -98,7 +96,7 @@ We can also write vector data to GeoPackage. Here we use `gpkg_write()` to add a
 # add bounding polygon vector layer via named list
 r <- gpkg_tables(gpkg_tmp)[['DEM1']]
 v <- terra::as.polygons(r, ext = TRUE)
-gpkg_write(list(bbox = v), destfile = gpkg_tmp)
+gpkg_write(list(bbox = v), gpkg_tmp)
 ```
 
 ## Insert Attribute Table
@@ -107,7 +105,7 @@ Similarly, `data.frame`-like objects (non-spatial "attributes") can be written t
 
 ```{r}
 z <- data.frame(a = 1:10, b = LETTERS[1:10])
-gpkg_write(list(myattr = z), destfile = gpkg_tmp)
+gpkg_write(list(myattr = z), gpkg_tmp)
 ```
 
 ## Read a GeoPackage

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ start by adding two DEM (GeoTIFF) files.
 ``` r
 library(gpkg)
 library(terra)
-#> terra 1.8.35
+#> terra 1.8.56
 
 dem <- system.file("extdata", "dem.tif", package = "gpkg")
 stopifnot(nchar(dem) > 0)
@@ -81,16 +81,14 @@ if (file.exists(gpkg_tmp))
 
 # write a gpkg with two DEMs in it
 gpkg_write(
-  dem,
-  destfile = gpkg_tmp,
+  dem, gpkg_tmp,
   RASTER_TABLE = "DEM1",
   FIELD_NAME = "Elevation"
 )
 #> Loading required namespace: gdalraster
 
 gpkg_write(
-  dem,
-  destfile = gpkg_tmp,
+  dem, gpkg_tmp,
   append = TRUE,
   RASTER_TABLE = "DEM2",
   FIELD_NAME = "Elevation",
@@ -107,7 +105,7 @@ to add a bounding box polygon layer derived from extent of `"DEM1"`.
 # add bounding polygon vector layer via named list
 r <- gpkg_tables(gpkg_tmp)[['DEM1']]
 v <- terra::as.polygons(r, ext = TRUE)
-gpkg_write(list(bbox = v), destfile = gpkg_tmp)
+gpkg_write(list(bbox = v), gpkg_tmp)
 ```
 
 ## Insert Attribute Table
@@ -117,7 +115,7 @@ written to GeoPackage.
 
 ``` r
 z <- data.frame(a = 1:10, b = LETTERS[1:10])
-gpkg_write(list(myattr = z), destfile = gpkg_tmp)
+gpkg_write(list(myattr = z), gpkg_tmp)
 ```
 
 ## Read a GeoPackage
@@ -141,7 +139,7 @@ g
 #>  rtree_bbox_geom_parent, rtree_bbox_geom_rowid, sqlite_sequence
 #> --------------------------------------------------------------------------------
 #> <SQLiteConnection>
-#>   Path: /tmp/RtmpgHnmwl/file1a1bd14d1754e.gpkg
+#>   Path: /tmp/RtmpDk7Fhe/filedd0d473fa3bd.gpkg
 #>   Extensions: TRUE
 class(g)
 #> [1] "geopackage"
@@ -204,32 +202,32 @@ gpkg_list_tables(g)
 gpkg_tables(g)
 #> $DEM1
 #> class       : SpatRaster 
-#> dimensions  : 30, 31, 1  (nrow, ncol, nlyr)
+#> size        : 30, 31, 1  (nrow, ncol, nlyr)
 #> resolution  : 0.008333333, 0.008333333  (x, y)
 #> extent      : 6.008333, 6.266667, 49.69167, 49.94167  (xmin, xmax, ymin, ymax)
 #> coord. ref. : lon/lat WGS 84 (EPSG:4326) 
-#> source      : file1a1bd14d1754e.gpkg:DEM1 
-#> varname     : file1a1bd14d1754e 
+#> source      : filedd0d473fa3bd.gpkg:DEM1 
+#> varname     : filedd0d473fa3bd 
 #> name        : DEM1 
 #> min value   :  195 
 #> max value   :  500 
 #> 
 #> $DEM2
 #> class       : SpatRaster 
-#> dimensions  : 30, 31, 1  (nrow, ncol, nlyr)
+#> size        : 30, 31, 1  (nrow, ncol, nlyr)
 #> resolution  : 0.008333333, 0.008333333  (x, y)
 #> extent      : 6.008333, 6.266667, 49.69167, 49.94167  (xmin, xmax, ymin, ymax)
 #> coord. ref. : lon/lat WGS 84 (EPSG:4326) 
-#> source      : file1a1bd14d1754e.gpkg:DEM2 
-#> varname     : file1a1bd14d1754e 
+#> source      : filedd0d473fa3bd.gpkg:DEM2 
+#> varname     : filedd0d473fa3bd 
 #> name        : DEM2 
 #> min value   :  195 
 #> max value   :  500 
 #> 
 #> $myattr
-#>                                      dsn table_name nrow table_info.cid
-#> 1 /tmp/RtmpgHnmwl/file1a1bd14d1754e.gpkg     myattr   10              0
-#> 2 /tmp/RtmpgHnmwl/file1a1bd14d1754e.gpkg     myattr   10              1
+#>                                     dsn table_name nrow table_info.cid
+#> 1 /tmp/RtmpDk7Fhe/filedd0d473fa3bd.gpkg     myattr   10              0
+#> 2 /tmp/RtmpDk7Fhe/filedd0d473fa3bd.gpkg     myattr   10              1
 #>   table_info.name table_info.type table_info.notnull table_info.dflt_value
 #> 1               a         INTEGER                  0                    NA
 #> 2               b            TEXT                  0                    NA
@@ -242,7 +240,7 @@ gpkg_tables(g)
 #>  geometry    : polygons 
 #>  dimensions  : 1, 0  (geometries, attributes)
 #>  extent      : 6.008333, 6.266667, 49.69167, 49.94167  (xmin, xmax, ymin, ymax)
-#>  source      : file1a1bd14d1754e.gpkg (bbox)
+#>  source      : filedd0d473fa3bd.gpkg (bbox)
 #>  coord. ref. : lon/lat WGS 84 (EPSG:4326)
 
 # inspect a specific table
@@ -287,13 +285,13 @@ returns a *tbl_SQLiteConnection*.
 tb <- gpkg_tbl(g, "gpkg_contents")
 tb
 #> # Source:   table<`gpkg_contents`> [?? x 10]
-#> # Database: sqlite 3.47.1 [/tmp/RtmpgHnmwl/file1a1bd14d1754e.gpkg]
+#> # Database: sqlite 3.50.0 [/tmp/RtmpDk7Fhe/filedd0d473fa3bd.gpkg]
 #>   table_name data_type   identifier description last_change   min_x min_y  max_x
 #>   <chr>      <chr>       <chr>      <chr>       <chr>         <dbl> <dbl>  <dbl>
-#> 1 DEM1       2d-gridded… DEM1       ""          2025-03-16…    6.01  49.7   6.27
-#> 2 DEM2       2d-gridded… DEM2       ""          2025-03-16…    6.01  49.7   6.27
-#> 3 bbox       features    bbox       ""          2025-03-16…    6.01  49.7   6.27
-#> 4 myattr     attributes  myattr     ""          2025-03-16… -180    -90   180   
+#> 1 DEM1       2d-gridded… DEM1       ""          2025-07-18…    6.01  49.7   6.27
+#> 2 DEM2       2d-gridded… DEM2       ""          2025-07-18…    6.01  49.7   6.27
+#> 3 bbox       features    bbox       ""          2025-07-18…    6.01  49.7   6.27
+#> 4 myattr     attributes  myattr     ""          2025-07-17… -180    -90   180   
 #> # ℹ 2 more variables: max_y <dbl>, srs_id <int>
 ```
 
@@ -302,9 +300,9 @@ Note that with this lazy reference to table, the internal
 
 ``` r
 gpkg_connection(g)@ptr
-#> <pointer: 0x59e83cdb9210>
+#> <pointer: 0x5d8d438b22b0>
 gpkg_connection(tb)@ptr
-#> <pointer: 0x59e83cdb9210>
+#> <pointer: 0x5d8d438b22b0>
 ```
 
 This means that you can handle all of your connections via the `connect`
@@ -324,10 +322,10 @@ gpkg_contents(g)
 #> 3       bbox            features       bbox            
 #> 4     myattr          attributes     myattr            
 #>                last_change       min_x     min_y      max_x    max_y srs_id
-#> 1 2025-03-16T17:34:06.422Z    6.008333  49.69167   6.266667 49.94167   4326
-#> 2 2025-03-16T17:34:06.505Z    6.008333  49.69167   6.266667 49.94167   4326
-#> 3 2025-03-16T17:34:06.716Z    6.008333  49.69167   6.266667 49.94167   4326
-#> 4 2025-03-16T10:34:06.753Z -180.000000 -90.00000 180.000000 90.00000   4326
+#> 1 2025-07-18T04:17:52.309Z    6.008333  49.69167   6.266667 49.94167   4326
+#> 2 2025-07-18T04:17:52.421Z    6.008333  49.69167   6.266667 49.94167   4326
+#> 3 2025-07-18T04:17:52.651Z    6.008333  49.69167   6.266667 49.94167   4326
+#> 4 2025-07-17T21:17:52.692Z -180.000000 -90.00000 180.000000 90.00000   4326
 ```
 
 ### Lazy Data Access
@@ -346,13 +344,13 @@ analysis.
 
 ``` r
 head(gpkg_table_pragma(g))
-#>                                      dsn table_name nrow table_info.cid
-#> 1 /tmp/RtmpgHnmwl/file1a1bd14d1754e.gpkg       DEM1    1              0
-#> 2 /tmp/RtmpgHnmwl/file1a1bd14d1754e.gpkg       DEM1    1              1
-#> 3 /tmp/RtmpgHnmwl/file1a1bd14d1754e.gpkg       DEM1    1              2
-#> 4 /tmp/RtmpgHnmwl/file1a1bd14d1754e.gpkg       DEM1    1              3
-#> 5 /tmp/RtmpgHnmwl/file1a1bd14d1754e.gpkg       DEM1    1              4
-#> 6 /tmp/RtmpgHnmwl/file1a1bd14d1754e.gpkg       DEM2    1              0
+#>                                     dsn table_name nrow table_info.cid
+#> 1 /tmp/RtmpDk7Fhe/filedd0d473fa3bd.gpkg       DEM1    1              0
+#> 2 /tmp/RtmpDk7Fhe/filedd0d473fa3bd.gpkg       DEM1    1              1
+#> 3 /tmp/RtmpDk7Fhe/filedd0d473fa3bd.gpkg       DEM1    1              2
+#> 4 /tmp/RtmpDk7Fhe/filedd0d473fa3bd.gpkg       DEM1    1              3
+#> 5 /tmp/RtmpDk7Fhe/filedd0d473fa3bd.gpkg       DEM1    1              4
+#> 6 /tmp/RtmpDk7Fhe/filedd0d473fa3bd.gpkg       DEM2    1              0
 #>   table_info.name table_info.type table_info.notnull table_info.dflt_value
 #> 1              id         INTEGER                  0                  <NA>
 #> 2      zoom_level         INTEGER                  1                  <NA>
@@ -380,7 +378,7 @@ gpkg_vect(g, 'bbox')
 #>  geometry    : polygons 
 #>  dimensions  : 1, 0  (geometries, attributes)
 #>  extent      : 6.008333, 6.266667, 49.69167, 49.94167  (xmin, xmax, ymin, ymax)
-#>  source      : file1a1bd14d1754e.gpkg (bbox)
+#>  source      : filedd0d473fa3bd.gpkg (bbox)
 #>  coord. ref. : lon/lat WGS 84 (EPSG:4326)
 ```
 
@@ -394,7 +392,7 @@ gpkg_vect(g, 'gpkg_ogr_contents')
 #>  geometry    : none 
 #>  dimensions  : 0, 2  (geometries, attributes)
 #>  extent      : 0, 0, 0, 0  (xmin, xmax, ymin, ymax)
-#>  source      : file1a1bd14d1754e.gpkg (SELECT)
+#>  source      : filedd0d473fa3bd.gpkg (SELECT)
 #>  coord. ref. :  
 #>  names       : table_name feature_count
 #>  type        :      <chr>         <num>
@@ -441,14 +439,14 @@ For example:
 ``` r
 gpkg_rast(g)
 #> class       : SpatRaster 
-#> dimensions  : 30, 31, 2  (nrow, ncol, nlyr)
+#> size        : 30, 31, 2  (nrow, ncol, nlyr)
 #> resolution  : 0.008333333, 0.008333333  (x, y)
 #> extent      : 6.008333, 6.266667, 49.69167, 49.94167  (xmin, xmax, ymin, ymax)
 #> coord. ref. : lon/lat WGS 84 (EPSG:4326) 
-#> sources     : file1a1bd14d1754e.gpkg:DEM1  
-#>               file1a1bd14d1754e.gpkg:DEM2  
-#> varnames    : file1a1bd14d1754e 
-#>               file1a1bd14d1754e 
+#> sources     : filedd0d473fa3bd.gpkg:DEM1  
+#>               filedd0d473fa3bd.gpkg:DEM2  
+#> varnames    : filedd0d473fa3bd 
+#>               filedd0d473fa3bd 
 #> names       : DEM1, DEM2 
 #> min values  :  195,  195 
 #> max values  :  500,  500
@@ -470,13 +468,13 @@ contains critical information on the data contained in a GeoPackage.
 ``` r
 gpkg_table(g, "gpkg_contents")
 #> # Source:   table<`gpkg_contents`> [?? x 10]
-#> # Database: sqlite 3.47.1 [/tmp/RtmpgHnmwl/file1a1bd14d1754e.gpkg]
+#> # Database: sqlite 3.50.0 [/tmp/RtmpDk7Fhe/filedd0d473fa3bd.gpkg]
 #>   table_name data_type   identifier description last_change   min_x min_y  max_x
 #>   <chr>      <chr>       <chr>      <chr>       <chr>         <dbl> <dbl>  <dbl>
-#> 1 DEM1       2d-gridded… DEM1       ""          2025-03-16…    6.01  49.7   6.27
-#> 2 DEM2       2d-gridded… DEM2       ""          2025-03-16…    6.01  49.7   6.27
-#> 3 bbox       features    bbox       ""          2025-03-16…    6.01  49.7   6.27
-#> 4 myattr     attributes  myattr     ""          2025-03-16… -180    -90   180   
+#> 1 DEM1       2d-gridded… DEM1       ""          2025-07-18…    6.01  49.7   6.27
+#> 2 DEM2       2d-gridded… DEM2       ""          2025-07-18…    6.01  49.7   6.27
+#> 3 bbox       features    bbox       ""          2025-07-18…    6.01  49.7   6.27
+#> 4 myattr     attributes  myattr     ""          2025-07-17… -180    -90   180   
 #> # ℹ 2 more variables: max_y <dbl>, srs_id <int>
 ```
 
@@ -529,7 +527,7 @@ gpkg_connect(g)
 #>  rtree_bbox_geom_parent, rtree_bbox_geom_rowid, sqlite_sequence
 #> --------------------------------------------------------------------------------
 #> <SQLiteConnection>
-#>   Path: /tmp/RtmpgHnmwl/file1a1bd14d1754e.gpkg
+#>   Path: /tmp/RtmpDk7Fhe/filedd0d473fa3bd.gpkg
 #>   Extensions: TRUE
 
 # disconnect

--- a/inst/tinytest/test_gpkg.R
+++ b/inst/tinytest/test_gpkg.R
@@ -31,8 +31,7 @@ if (file.exists(gpkg_tmp))
 
 # write a gpkg with two DEMs in it
 gpkg_write(
-  dem,
-  destfile = gpkg_tmp,
+  dem, gpkg_tmp,
   RASTER_TABLE = "DEM1",
   FIELD_NAME = "Elevation"
 )
@@ -41,8 +40,7 @@ gpkg_write(
 expect_error(gpkg_write(dem, gpkg_tmp))
 
 gpkg_write(
-  dem,
-  destfile = gpkg_tmp,
+  dem, gpkg_tmp,
   append = TRUE,
   RASTER_TABLE = "DEM2",
   FIELD_NAME = "Elevation",
@@ -80,8 +78,8 @@ tfgpkg <- tempfile(fileext = ".gpkg")
 rdem <- terra::rast(dem)
 v <- terra::as.polygons(rdem, ext = TRUE)
 
-# expect_error(gpkg_write(list(testgpkg = tfgpkg), destfile = tfgpkg))
-expect_silent(gpkg_write(list(testgpkg = v), destfile = tfgpkg))
+# expect_error(gpkg_write(list(testgpkg = tfgpkg), tfgpkg))
+expect_silent(gpkg_write(list(testgpkg = v), tfgpkg))
 v <- terra::crop(v, terra::ext(rdem) / 2)
 expect_true(is.character(gpkg_list_tables(tfgpkg)))
 write.csv(data.frame(id = 1:3, code = LETTERS[1:3]), tfcsv)
@@ -148,7 +146,7 @@ gpkg_disconnect(g4)
 
 # add bounding polygon vector dataset
 b <- terra::as.polygons(gpkg_rast(g, "DEM1"), ext = TRUE)
-expect_silent(gpkg_write(list(layer1 = b, layerB = b), destfile = gpkg_tmp, append = TRUE))
+expect_silent(gpkg_write(list(layer1 = b, layerB = b), gpkg_tmp, append = TRUE))
 
 if (utils::packageVersion("terra") >= "1.7.33") {
   res <- gpkg_ogr_query(g, "SELECT
@@ -164,7 +162,7 @@ gpkg_disconnect(g)
 
 # TODO: writing attributes leaves connection open
 d  <- data.frame(a = 1:10, b = LETTERS[1:10])
-expect_silent(gpkg_write(list(myattr = d), destfile = gpkg_tmp))
+expect_silent(gpkg_write(list(myattr = d), gpkg_tmp))
 
 # enumerate tables
 tl <- gpkg_list_tables(g)

--- a/man/gpkg_table.Rd
+++ b/man/gpkg_table.Rd
@@ -92,13 +92,11 @@ tf <- tempfile(fileext = ".gpkg")
 
 r <- terra::rast(system.file("extdata", "dem.tif", package = "gpkg"))
 
-gpkg_write(r,
-           destfile = tf,
+gpkg_write(r, tf,
            RASTER_TABLE = "DEM1",
            FIELD_NAME = "Elevation")
 
-gpkg_write(r,
-           destfile = tf,
+gpkg_write(r, tf,
            append = TRUE,
            RASTER_TABLE = "DEM2",
            FIELD_NAME = "Elevation")

--- a/man/gpkg_write.Rd
+++ b/man/gpkg_write.Rd
@@ -6,39 +6,42 @@
 \usage{
 gpkg_write(
   x,
-  destfile,
+  y = NULL,
   table_name = NULL,
   datatype = "FLT4S",
   append = FALSE,
   overwrite = FALSE,
   NoData = NULL,
   gdal_options = NULL,
+  destfile = NULL,
   ...
 )
 }
 \arguments{
 \item{x}{Vector of source file path(s), or a list containing one or more
-SpatRaster, SpatRasterCollection, or SpatVectorProxy objects.}
+SpatRaster, SpatRasterCollection, SpatVectorProxy, or data.frame objects.}
 
-\item{destfile}{Character. Path to output GeoPackage}
+\item{y}{\emph{character}, \emph{geopackage}, or \emph{DBIConnection}.}
 
-\item{table_name}{Character. Default \code{NULL} name is derived from source file.
+\item{table_name}{\emph{character}. Default \code{NULL} name is derived from source file.
 Required if \code{x} is a \emph{data.frame}.}
 
-\item{datatype}{Data type. Defaults to \code{"FLT4S"} for GeoTIFF files, \code{"INT2U"}
+\item{datatype}{\emph{character}. Data type. Defaults to \code{"FLT4S"} for GeoTIFF files, \code{"INT2U"}
 otherwise. See documentation for \code{terra::writeRaster()}.}
 
-\item{append}{Append to existing data source? Default: \code{FALSE}. Setting
+\item{append}{\emph{logical}. Append to existing data source? Default: \code{FALSE}. Setting
 \code{append=TRUE} overrides \code{overwrite=TRUE}}
 
-\item{overwrite}{Overwrite existing data source? Default \code{FALSE}.}
+\item{overwrite}{\emph{logical}. Overwrite existing data source? Default \code{FALSE}.}
 
-\item{NoData}{Value to use as GDAL \code{NoData} Value}
+\item{NoData}{\emph{numeric}. Value to use as GDAL \code{NoData} Value}
 
-\item{gdal_options}{Additional \code{gdal_options}, passed to
+\item{gdal_options}{\emph{character}. Additional \code{gdal_options}, passed to
 \code{terra::writeRaster()}}
 
-\item{...}{Additional arguments are passed as GeoPackage "creation options."
+\item{destfile}{\emph{character}. Path to output GeoPackage}
+
+\item{...}{Additional arguments are passed as GeoPackage creation options.
 See Details.}
 }
 \value{

--- a/misc/gpkg-raster.R
+++ b/misc/gpkg-raster.R
@@ -35,13 +35,13 @@ r <- terra::classify(r,
 
 gpkg_write(
   list(bar = terra::rast("foo.tif")),
+  "test.gpkg",
   NoData = -9999,
-  destfile = "test.gpkg",
   overwrite = TRUE
 )
 
 gpkg_write(list(foo = terra::vect("test.shp", proxy = TRUE)),
-           destfile = "test.gpkg",
+           "test.gpkg",
            append = TRUE)
 
 x2 <- terra::rast("test.gpkg")

--- a/misc/gpkg-view-voronoi.R
+++ b/misc/gpkg-view-voronoi.R
@@ -8,7 +8,7 @@ if (file.exists(gpkg_tmp))
 
 v <- vect(system.file("ex", "lux.shp", package = "terra"))
 
-gpkg_write(list(lux = v), destfile = gpkg_tmp, append = TRUE)
+gpkg_write(list(lux = v), gpkg_tmp, append = TRUE)
 
 g <- geopackage(gpkg_tmp, connect = TRUE)
 

--- a/misc/test-gpkg_write.R
+++ b/misc/test-gpkg_write.R
@@ -3,8 +3,8 @@ library(gpkg)
 options(gpkg.debug = TRUE)
 
 gpkg_write("~/Geodata/ISSR800/caco3_kg_sq_m.tif",
+           "misc/caco3.gpkg", 
            overwrite = TRUE, 
-           destfile = "misc/caco3.gpkg", 
            RASTER_TABLE = "caco3_kg_sq_m", 
            RASTER_IDENTIFIER = "caco3_kg_sq_m",
            RASTER_DESCRIPTION = "Calcium Carbonate Surface Density (kilograms per square meter)",
@@ -16,7 +16,7 @@ gpkg_write("~/Geodata/ISSR800/caco3_kg_sq_m.tif",
 # Would be more efficient w/ smaller tiles and NoData mapped to something other than 0; looking into it
 
 gpkg_write("~/Geodata/ISSR800/ec.tif",
-           destfile = "misc/caco3.gpkg",
+           "misc/caco3.gpkg",
            append = TRUE, 
            RASTER_TABLE = "ec", 
            RASTER_IDENTIFIER = "ec",

--- a/vignettes/intro.Rmd
+++ b/vignettes/intro.Rmd
@@ -50,14 +50,14 @@ if (file.exists(gpkg_tmp))
 # write a gpkg with two DEMs in it
 gpkg_write(
   dem,
-  destfile = gpkg_tmp,
+  gpkg_tmp,
   RASTER_TABLE = "DEM1",
   FIELD_NAME = "Elevation"
 )
 
 gpkg_write(
   dem,
-  destfile = gpkg_tmp,
+  gpkg_tmp,
   append = TRUE,
   RASTER_TABLE = "DEM2",
   FIELD_NAME = "Elevation",
@@ -73,7 +73,7 @@ We can also write vector data to GeoPackage. Here we use `gpkg_write()` to add a
 # add bounding polygon vector layer via named list
 r <- gpkg_tables(gpkg_tmp)[['DEM1']]
 v <- terra::as.polygons(r, ext = TRUE)
-gpkg_write(list(bbox = v), destfile = gpkg_tmp)
+gpkg_write(list(bbox = v), gpkg_tmp)
 ```
 
 ## Insert Attribute Table
@@ -82,7 +82,7 @@ Similarly, `data.frame`-like objects (non-spatial "attributes") can be written t
 
 ```{r}
 z <- data.frame(a = 1:10, b = LETTERS[1:10])
-gpkg_write(list(myattr = z), destfile = gpkg_tmp)
+gpkg_write(list(myattr = z), gpkg_tmp)
 ```
 
 ## Read a GeoPackage


### PR DESCRIPTION
Closes #25: `destfile` has been replaced with new argument `y` that accepts a geopackage or DBIConnection object as input